### PR TITLE
Remove incorrect option to change endpoint name

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,6 @@ Ensure that you have the example application running on your Linux environment (
 		- **/Test/0/D** represents the dynamic resource that the mbed DS can read. The example program automatically increments the resource's value every 10 seconds, displaying **Resource Value /Test/0/D : <Value>** on the console. The value starts from zero and the increments are steps of one. 
 		- **/Test/0/S** represents the static resource that has a fixed value in the mbed Client. 
 
-**NOTE:** If you changed your endpoint's name (the variable `MBED_ENDPOINT_NAME` in `sources/security.h`) from the default `mbed-linux-endpoint`, you will need to change it in the above URLs as well.
-
 For more information on the mbed Device Connector REST API, see help pages.
 
 To stop and deregister the mbed Client example, you need to interrupt the program by pressing CTRL+C. This sends an unregister message to mbed DS. The console displays **Unregistering endpoint**. After a successful deregistration, the console displays **Unregistration done --> exiting** and terminates the program. Also, the endpoint disappears from the **Connected devices** list on the mbed Device Connector web UI.


### PR DESCRIPTION
We don't support changing endpoint names anymore using a secured connection, so removing this note.